### PR TITLE
mysql2 0.4+ supports prepared statements

### DIFF
--- a/lib/mysql2-cs-bind.rb
+++ b/lib/mysql2-cs-bind.rb
@@ -11,7 +11,10 @@ class Mysql2::Client
     if args.size < 1
       query(sql, options)
     else
-      query(Mysql2::Client.pseudo_bind(sql, args), options)
+      Thread.exclusive do
+        @query_options.merge! options
+        prepare(sql).execute(args)
+      end
     end
   end
 

--- a/mysql2-cs-bind.gemspec
+++ b/mysql2-cs-bind.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "mysql2"  
+  gem.add_runtime_dependency "mysql2", "~> 0.4.0"
 
   # tests
   gem.add_development_dependency 'eventmachine'


### PR DESCRIPTION
After five yerars, mysql2 gem now has native support of prepared statement cf: https://github.com/brianmario/mysql2/pull/591

I think this library served its purpose.  Users can just remove this library.  But the API introduced into mysql2 canon differs from this one.  I guess there needs a migration path.