### PR TITLE
Improve performance for `Mysql2::Client#xquery`

### DIFF
--- a/lib/mysql2-cs-bind.rb
+++ b/lib/mysql2-cs-bind.rb
@@ -21,8 +21,11 @@ class Mysql2::Client
       placeholders.push(pos)
       search_pos = pos + 1
     end
-    values = values.flatten(1) if placeholders.length == values.flatten(1).length
-    raise ArgumentError, "mismatch between placeholders number and values arguments" if placeholders.length != values.length
+
+    if placeholders.length != values.length &&
+       placeholders.length != (values = values.flatten(1)).length
+      raise ArgumentError, "mismatch between placeholders number and values arguments"
+    end
 
     while pos = placeholders.pop()
       rawvalue = values.pop()

--- a/lib/mysql2-cs-bind.rb
+++ b/lib/mysql2-cs-bind.rb
@@ -43,16 +43,19 @@ class Mysql2::Client
   private
 
   def self.quote(rawvalue)
-    if rawvalue.nil?
+    case rawvalue
+    when nil
       'NULL'
-    elsif rawvalue == true
+    when true
       'TRUE'
-    elsif rawvalue == false
+    when false
       'FALSE'
-    elsif rawvalue.respond_to?(:strftime)
-      "'#{rawvalue.strftime('%Y-%m-%d %H:%M:%S')}'"
     else
-      "'#{Mysql2::Client.escape(rawvalue.to_s)}'"
+      if rawvalue.respond_to?(:strftime)
+        "'#{rawvalue.strftime('%Y-%m-%d %H:%M:%S')}'"
+      else
+        "'#{Mysql2::Client.escape(rawvalue.to_s)}'"
+      end
     end
   end
 end

--- a/lib/mysql2-cs-bind.rb
+++ b/lib/mysql2-cs-bind.rb
@@ -4,13 +4,8 @@ require 'mysql2'
 
 class Mysql2::Client
 
-  def xquery(sql, *args)
-    options = if args.size > 0 and args[-1].is_a?(Hash)
-                args.pop
-              else
-                {}
-              end
-    if args.size < 1
+  def xquery(sql, *args, **options)
+    if args.empty?
       query(sql, options)
     else
       query(Mysql2::Client.pseudo_bind(sql, args), options)


### PR DESCRIPTION
This PR includes three performance improvements.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "mysql2"
  gem "benchmark-ips"
end

puts RUBY_VERSION

class Mysql2::Client
  def self.xquery(sql, *args)
    options = if args.size > 0 and args[-1].is_a?(Hash)
                args.pop
              else
                {}
              end
    args.size < 1
  end

  def self.xquery2(sql, *args, **options)
    args.empty?
  end

  def self.quote(rawvalue)
    if rawvalue.nil?
      'NULL'
    elsif rawvalue == true
      'TRUE'
    elsif rawvalue == false
      'FALSE'
    elsif rawvalue.respond_to?(:strftime)
      "'#{rawvalue.strftime('%Y-%m-%d %H:%M:%S')}'"
    else
      "'#{Mysql2::Client.escape(rawvalue.to_s)}'"
    end
  end

  def self.quote2(rawvalue)
    case rawvalue
    when nil
      'NULL'
    when true
      'TRUE'
    when false
      'FALSE'
    else
      if rawvalue.respond_to?(:strftime)
        "'#{rawvalue.strftime('%Y-%m-%d %H:%M:%S')}'"
      else
        "'#{Mysql2::Client.escape(rawvalue.to_s)}'"
      end
    end
  end
end

placeholders = [1]
_values = ["arg"]

Benchmark.ips do |x|
  x.report("xquery") { Mysql2::Client.xquery("sql", "arg") }
  x.report("xquery2") { Mysql2::Client.xquery2("sql", "arg") }
end

Benchmark.ips do |x|
  x.report("quote") { Mysql2::Client.quote("foo") }
  x.report("quote2") { Mysql2::Client.quote2("foo") }
end

Benchmark.ips do |x|
  x.report("pseudo_bind") do
    values = _values

    values = values.flatten(1) if placeholders.length == values.flatten(1).length
    raise ArgumentError, "mismatch between placeholders number and values arguments" if placeholders.length != values.length
  end

  x.report("pseudo_bind2") do
    values = _values

    if placeholders.length != values.length &&
       placeholders.length != (values = values.flatten(1)).length
      raise ArgumentError, "mismatch between placeholders number and values arguments"
    end
  end
end
```

```
3.0.0
Warming up --------------------------------------
              xquery   371.511k i/100ms
             xquery2   485.925k i/100ms
Calculating -------------------------------------
              xquery      3.651M (± 2.9%) i/s -     18.576M in   5.092640s
             xquery2      4.838M (± 8.6%) i/s -     24.296M in   5.069563s
Warming up --------------------------------------
               quote   114.220k i/100ms
              quote2   155.510k i/100ms
Calculating -------------------------------------
               quote      1.184M (± 4.9%) i/s -      5.939M in   5.031059s
              quote2      1.545M (± 2.5%) i/s -      7.776M in   5.035340s
Warming up --------------------------------------
         pseudo_bind   220.249k i/100ms
        pseudo_bind2     1.041M i/100ms
Calculating -------------------------------------
         pseudo_bind      2.176M (± 4.2%) i/s -     11.012M in   5.072696s
        pseudo_bind2     10.359M (± 4.1%) i/s -     52.070M in   5.036850s
```