### PR TITLE
Remove specs for Ruby 1.9

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -21,7 +21,7 @@ describe Mysql2::Client do
       @klass.pseudo_bind("SELECT x,y,z FROM x WHERE x=?", [1]).should eql("SELECT x,y,z FROM x WHERE x='1'")
       @klass.pseudo_bind("SELECT x,y,z FROM x WHERE x=? AND y=?", [1, 'X']).should eql("SELECT x,y,z FROM x WHERE x='1' AND y='X'")
     end
-      
+
     it "should raise ArgumentError if mismatch exists between placeholders and arguments" do
       expect {
         @klass.pseudo_bind("SELECT x,y,z FROM x", [1])
@@ -126,11 +126,5 @@ describe Mysql2::Client do
 
   it "should respond to escape" do
     Mysql2::Client.should respond_to(:escape)
-  end
-
-  if RUBY_VERSION =~ /1.9/
-    it "should respond to #encoding" do
-      @client.should respond_to(:encoding)
-    end
   end
 end

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -34,36 +34,4 @@ describe Mysql2::Error do
   it "should alias #message to #error" do
     @error.should respond_to(:error)
   end
-
-  if RUBY_VERSION =~ /1.9/
-    it "#message encoding should match the connection's encoding, or Encoding.default_internal if set" do
-      if Encoding.default_internal.nil?
-        @error.message.encoding.should eql(@client.encoding)
-        @error2.message.encoding.should eql(@client2.encoding)
-      else
-        @error.message.encoding.should eql(Encoding.default_internal)
-        @error2.message.encoding.should eql(Encoding.default_internal)
-      end
-    end
-
-    it "#error encoding should match the connection's encoding, or Encoding.default_internal if set" do
-      if Encoding.default_internal.nil?
-        @error.error.encoding.should eql(@client.encoding)
-        @error2.error.encoding.should eql(@client2.encoding)
-      else
-        @error.error.encoding.should eql(Encoding.default_internal)
-        @error2.error.encoding.should eql(Encoding.default_internal)
-      end
-    end
-
-    it "#sql_state encoding should match the connection's encoding, or Encoding.default_internal if set" do
-      if Encoding.default_internal.nil?
-        @error.sql_state.encoding.should eql(@client.encoding)
-        @error2.sql_state.encoding.should eql(@client2.encoding)
-      else
-        @error.sql_state.encoding.should eql(Encoding.default_internal)
-        @error2.sql_state.encoding.should eql(Encoding.default_internal)
-      end
-    end
-  end
 end


### PR DESCRIPTION
mysql2-cs-bind 0.1.0 requires Ruby 2.0+ since 90b91cef.